### PR TITLE
Feature/removing game object crash cu e532hm

### DIFF
--- a/Project/.clang-format
+++ b/Project/.clang-format
@@ -11,7 +11,7 @@ AlignConsecutiveDeclarations: false
 AlignConsecutiveMacros: false
 AlignEscapedNewlines: Left
 AlignOperands: true
-AlignTrailingComments: false
+AlignTrailingComments: true
 
 AllowAllArgumentsOnNextLine: false
 AllowAllConstructorInitializersOnNextLine: false

--- a/Project/Source/Panels/PanelHierarchy.cpp
+++ b/Project/Source/Panels/PanelHierarchy.cpp
@@ -44,6 +44,7 @@ void PanelHierarchy::UpdateHierarchyNode(GameObject* gameObject) {
 
 	ImGui::PushID(label);
 	if (ImGui::BeginPopupContextItem("Options")) {
+		App->editor->selectedGameObject = gameObject;
 		if (gameObject != App->scene->root) {
 			if (ImGui::Selectable("Delete")) {
 				App->scene->DestroyGameObject(gameObject);


### PR DESCRIPTION
When deleting a game object that one of its children was selected, the flag isSelected was not set to nullptr.

In order to solve this problem, we change te default behaviour to set the game object selected when opening the options pop up