### PR TITLE
FIXED Crash on removing GameObjects

### DIFF
--- a/Project/Source/Modules/ModuleRender.cpp
+++ b/Project/Source/Modules/ModuleRender.cpp
@@ -282,12 +282,10 @@ void ModuleRender::DrawSceneRecursive(const Quadtree<GameObject>::Node& node, co
 				GameObject* gameObject = element->object;
 				if (!gameObject->flag) {
 					ComponentBoundingBox* boundingBox = gameObject->GetComponent<ComponentBoundingBox>();
-					if (boundingBox) {
-						const AABB& gameObjectAABB = boundingBox->GetWorldAABB();
-						const OBB& gameObjectOBB = boundingBox->GetWorldOBB();
-						if (CheckIfInsideFrustum(gameObjectAABB, gameObjectOBB)) {
-							DrawGameObject(gameObject);
-						}
+					const AABB& gameObjectAABB = boundingBox->GetWorldAABB();
+					const OBB& gameObjectOBB = boundingBox->GetWorldOBB();
+					if (CheckIfInsideFrustum(gameObjectAABB, gameObjectOBB)) {
+						DrawGameObject(gameObject);
 					}
 					gameObject->flag = true;
 				}

--- a/Project/Source/Modules/ModuleRender.cpp
+++ b/Project/Source/Modules/ModuleRender.cpp
@@ -282,12 +282,13 @@ void ModuleRender::DrawSceneRecursive(const Quadtree<GameObject>::Node& node, co
 				GameObject* gameObject = element->object;
 				if (!gameObject->flag) {
 					ComponentBoundingBox* boundingBox = gameObject->GetComponent<ComponentBoundingBox>();
-					const AABB& gameObjectAABB = boundingBox->GetWorldAABB();
-					const OBB& gameObjectOBB = boundingBox->GetWorldOBB();
-					if (CheckIfInsideFrustum(gameObjectAABB, gameObjectOBB)) {
-						DrawGameObject(gameObject);
+					if (boundingBox) {
+						const AABB& gameObjectAABB = boundingBox->GetWorldAABB();
+						const OBB& gameObjectOBB = boundingBox->GetWorldOBB();
+						if (CheckIfInsideFrustum(gameObjectAABB, gameObjectOBB)) {
+							DrawGameObject(gameObject);
+						}
 					}
-
 					gameObject->flag = true;
 				}
 				element = element->next;

--- a/Project/Source/Panels/PanelHierarchy.cpp
+++ b/Project/Source/Panels/PanelHierarchy.cpp
@@ -55,8 +55,8 @@ void PanelHierarchy::UpdateHierarchyNode(GameObject* gameObject) {
 		App->editor->selectedGameObject = gameObject;
 		if (gameObject != App->scene->root) {
 			if (ImGui::Selectable("Delete")) {
+				if (App->editor->selectedGameObject == gameObject) App->editor->selectedGameObject = nullptr;
 				App->scene->DestroyGameObject(gameObject);
-				if (isSelected) App->editor->selectedGameObject = nullptr;
 			}
 
 			if (ImGui::Selectable("Duplicate")) {

--- a/Project/Source/Panels/PanelHierarchy.cpp
+++ b/Project/Source/Panels/PanelHierarchy.cpp
@@ -55,7 +55,7 @@ void PanelHierarchy::UpdateHierarchyNode(GameObject* gameObject) {
 		App->editor->selectedGameObject = gameObject;
 		if (gameObject != App->scene->root) {
 			if (ImGui::Selectable("Delete")) {
-				if (App->editor->selectedGameObject == gameObject) App->editor->selectedGameObject = nullptr;
+				if (isSelected) App->editor->selectedGameObject = nullptr;
 				App->scene->DestroyGameObject(gameObject);
 			}
 

--- a/Project/Source/Utils/Quadtree.h
+++ b/Project/Source/Utils/Quadtree.h
@@ -55,17 +55,16 @@ public:
 			if (IsBranch()) {
 				childNodes->Remove(tree, object);
 			} else {
-				Element* element = firstElement;
 				Element** elementPtr = &firstElement;
+				Element* element = firstElement;
 				while (element != nullptr) {
 					if (element->object == object) {
 						*elementPtr = element->next;
 						tree.elements.Release(element);
 						elementCount -= 1;
 					}
-
-					element = element->next;
 					elementPtr = &element->next;
+					element = element->next;
 				}
 			}
 		}
@@ -126,7 +125,7 @@ public:
 		int elementCount = 0; // Leaf: number of elements. Branch: -1.
 		union {
 			Element* firstElement = nullptr; // Leaf only: first element.
-			QuadNode* childNodes; // Branch only: child nodes index.
+			QuadNode* childNodes;			 // Branch only: child nodes index.
 			std::list<Element>* tempElementList;
 		};
 	};
@@ -277,8 +276,8 @@ public:
 
 public:
 	AABB2D bounds = {{0, 0}, {0, 0}}; // Bounds of the quadtree. All elements should be contained inside this.
-	unsigned maxDepth = 0; // Max depth of the tree. Useful to avoid infinite divisions. This should be >= 1.
-	unsigned maxNodeElements = 0; // Max number of elements before a node is divided.
+	unsigned maxDepth = 0;			  // Max depth of the tree. Useful to avoid infinite divisions. This should be >= 1.
+	unsigned maxNodeElements = 0;	  // Max number of elements before a node is divided.
 
 	Node root;
 	Pool<QuadNode> quadNodes;


### PR DESCRIPTION
No estoy seguro si el `gameObject->flag = true;` deberia ir tambien dentro del `if(boundingBox)`.

En principio esto deberia arreglar el error, aunque me sorprende mucho que el error saltara ahí :S
O mejor dicho, por qué no saltaba aunque no se deleteen los objetos.

El engine petaba cuando eliminas el BabyPlayer, que es un objeto sin mesh->sin BB, y la camara no lo estaba enfocando (osea BabyP esta fuera del frustum). PERO solo peta cuando eliminar BabyPlayer es lo primero que haces, antes de mover incluso la camara. Si mueves un poco la camara y luego lo eliminas no petaba. No sé si puede haber algo mas profundo por ahi haciendo cosas raras.